### PR TITLE
expose nunjucks.configure in API

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,3 +52,5 @@ exports.render = function(context){
     });
 
 };
+
+exports.configure = nunjucks.configure;


### PR DESCRIPTION
My use case is to disable `watch`, which is `true` by default.
https://mozilla.github.io/nunjucks/api.html#configure

I'm rendering templates, writing them to files, and exiting. If `watch` is left on, the process doesn't exit.

(Also - thanks for making this! It's exactly what I needed.)
