### PR TITLE
`relative` property in README code snippet [possible fix]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ gulp.task('html', function(){
     return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false})
         .pipe( data(function(file){
             return requireNew(file.path);
-        }) );
+        }))
         .pipe( nunj.template('foobar.nunj') )
         .pipe( rename({ extname: '.html' })
         .pipe( gulp.dest('dest') )
@@ -93,9 +93,9 @@ gulp.task('html', function(){
     return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false})
         .pipe( data(function(file){
             return requireNew(file.path);
-        }) );
+        }))
         .pipe( nunj.template(function(file){
-            if(file.relative === 'foo.js'){
+            if(file.data.relative === 'foo.js'){
                 return 'preview.nunj';
             }
             return 'feature.nunj';


### PR DESCRIPTION
I was wondering if the README code snippet was correct because I have used this module for one of my implementations and the `file` object that I get in `nunj.template` is the Gulp file object with a `data` property with the value returned by `data` plugin.

I could open an issue, asking but I thought that send a PR where you can see the diff of the change was easier than trying to explain with words a code snippets in the comment box of an issue.
