### PR TITLE
Add short summary for render and template methods.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,18 @@ While not required, `gulp-data` and `gulp-rename` are very useful with this plug
 
 ```
 // Render gulp.src as nunjucks template(s).
+// Use "render" when each source file is a nunjucks template.
+// A simple use-case is to render a static site using nunjucks features such
+// as include, extends etc.
 require('gulp-render-nunjucks').render( [data] );
 ```
 
 ```
-// Render template.nunj for each file in gulp.src
-require('gulp-render-nunjucks').template('template.nunj')
+// Render template.njk for each file in gulp.src
+// Use "template" to pass the source files as data to the template.
+// A simple use case is a gulp.src of json, where each file should be rendered using the same
+// template.
+require('gulp-render-nunjucks').template('template.njk')
 ```
 
 
@@ -38,14 +44,13 @@ require('gulp-render-nunjucks').template('template.nunj')
 
 ```
 var rename = require('gulp-rename');
-var nunj = require('gulp-render-nunjucks');
+var njk = require('gulp-render-nunjucks');
 
 gulp.task('html', function(){
-    return gulp.src(['tpl1.nunj', 'tpl2.nunj'])
-        .pipe( nunj.render() )
-        .pipe( rename({ extname: '.html' })
-        .pipe( gulp.dest('dest') )
-        ;
+    return gulp.src(['tpl1.njk', 'tpl2.njk'])
+        .pipe(njk.render())
+        .pipe(rename({ extname: '.html' })
+        .pipe(gulp.dest('dest'));
 });
 ```
 
@@ -55,24 +60,23 @@ dest/tpl1.html
 dest/tpl2.html
 ```
 
-### template('template-name.nunj')
+### template('template-name.njk')
 
 **gulpfile.js**
 ```
 var data        = require('gulp-data');
 var rename      = require('gulp-rename');
 var requireNew  = require('require-new');
-var nunj        = require('gulp-render-nunjucks');
+var njk         = require('gulp-render-nunjucks');
 
 gulp.task('html', function(){
-    return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false})
-        .pipe( data(function(file){
+    return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false })
+        .pipe(data(function (file) {
             return requireNew(file.path);
-        }) );
-        .pipe( nunj.template('foobar.nunj') )
-        .pipe( rename({ extname: '.html' })
-        .pipe( gulp.dest('dest') )
-        ;
+        }))
+        .pipe(njk.template('foobar.njk'))
+        .pipe(rename({ extname: '.html' })
+        .pipe(gulp.dest('dest'));
 });
 ```
 **output**
@@ -87,35 +91,34 @@ dest/bar.html
 var data        = require('gulp-data');
 var rename      = require('gulp-rename');
 var requireNew  = require('require-new');
-var nunj        = require('gulp-render-nunjucks');
+var njk        = require('gulp-render-nunjucks');
 
-gulp.task('html', function(){
-    return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false})
-        .pipe( data(function(file){
+gulp.task('html', function () {
+    return gulp.src(['data/foo.js', 'data/bar.json'], { base: 'data', read: false })
+        .pipe(data(function (file) {
             return requireNew(file.path);
-        }) );
-        .pipe( nunj.template(function(file){
+        }))
+        .pipe(njk.template(function (file) {
             if(file.relative === 'foo.js'){
-                return 'preview.nunj';
+                return 'preview.njk';
             }
-            return 'feature.nunj';
-        }) )
-        .pipe( rename({ extname: '.html' })
-        .pipe( gulp.dest('dest') )
-        ;
+            return 'feature.njk';
+        }))
+        .pipe(rename({ extname: '.html' })
+        .pipe(gulp.dest('dest'));
 });
 ```
+
 **output**
 ```
-dest/foo.html   // rendered using preview.nunj
-dest/bar.html   // rendered using feature.nunj
+dest/foo.html   // rendered using preview.njk
+dest/bar.html   // rendered using feature.njk
 ```
 
 ## notes
 
 If using gulp-data and passing a data context to render(), a merged context will be passed to the template.
-When merging the data, keys from `file.data` (from `gulp-data`) will overwrite the default data context passed to 
-render().
+When merging the data, keys from `file.data` (from `gulp-data`) will overwrite the default data context passed to  render().
   
 For example:
 
@@ -123,21 +126,20 @@ For example:
 ```
 var data = require('gulp-data');
 var rename = require('gulp-rename');
-var nunj = require('gulp-render-nunjucks');
+var njk = require('gulp-render-nunjucks');
 
-gulp.task('html', function(){
-    return gulp.src(['tpl1.nunj', 'tpl2.nunj'])
-        .pipe( data(function(file){
+gulp.task('html', function () {
+    return gulp.src(['tpl1.njk', 'tpl2.njk'])
+        .pipe(data(function (file) {
             return {
                 // 1. 'message' will not be overwritten when data is merged  
                 message: 'hello from ' + file.relative
             }
-        }) )
+        }))
         // 2. 'message' will be overwritten with the value from gulp-data.
-        .pipe( nunj.render({ message: 'hello') )
-        .pipe( rename({ extname: '.html' })
-        .pipe( gulp.dest('dest') )
-        ;
+        .pipe(njk.render({ message: 'hello'))
+        .pipe(rename({ extname: '.html' })
+        .pipe(gulp.dest('dest'));
 });
 ```
 
@@ -151,5 +153,4 @@ dest/tpl2.html  // message = 'hello from tpl2.html'
 ## tests
 
 `npm test` (or `mocha`) - Runs all tests
-
 `npm run coverage` - Check code coverage


### PR DESCRIPTION
Improve code examples in readme.md
- use .njk extension instead of .nunj
- use consistent code style
- remove errornous semi-colons
